### PR TITLE
Allow using pagesdisplay in user and file blueprints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "rasteiner/k3-pagesdisplay-section",
   "description": "K3 plugin: display any page list in a section. Any parent, many parents, filtered, don't care.",
   "type": "kirby-plugin",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "authors": [
     {
       "name": "Roman Steiner",

--- a/src/PagesDisplaySection.php
+++ b/src/PagesDisplaySection.php
@@ -29,6 +29,19 @@ $extension = [
         'type' => fn() => 'pages',
     ],
     'computed' => [
+        'parent' => function () {
+            $parent = $this->parentModel();
+
+            if (
+                $parent instanceof \Kirby\Cms\Site === false &&
+                $parent instanceof \Kirby\Cms\Page === false &&
+                $this->query === 'page.children'
+            ) {
+                throw new InvalidArgumentException("You must provide a query when using pagesdisplay in a user or file blueprint.");
+            }
+
+            return $parent;
+        },
         'pages' => function () {
             $kirby = kirby();
             $q = new Query($this->query, [

--- a/src/PagesDisplaySection.php
+++ b/src/PagesDisplaySection.php
@@ -2,7 +2,9 @@
 
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Cms\Section;
-use Kirby\Toolkit\Query;
+use Kirby\Cms\Page;
+use Kirby\Cms\Site;
+use Kirby\Cms\User;
 
 $base = Section::$types['pages'];
 
@@ -15,7 +17,7 @@ $extension = [
         'sortable' => function (bool $sortable = true) {
             return false;
         },
-        'query' => function (string $query = 'page.children') {
+        'query' => function (string $query = null) {
             return $query;
         },
         'controls' => function ($controls = true) {
@@ -30,28 +32,39 @@ $extension = [
     ],
     'computed' => [
         'parent' => function () {
-            $parent = $this->parentModel();
-
-            if (
-                $parent instanceof \Kirby\Cms\Site === false &&
-                $parent instanceof \Kirby\Cms\Page === false &&
-                $this->query === 'page.children'
-            ) {
-                throw new InvalidArgumentException("You must provide a query when using pagesdisplay in a user or file blueprint.");
-            }
-
-            return $parent;
+            return $this->parentModel();
         },
         'pages' => function () {
+            $model = $this->parentModel();
+
+            $query = $this->query ?? match(true) {
+                is_a($model, Site::class) => 'pages',
+                is_a($model, User::class) => 'pages',
+                default => 'page.children',
+            };
+            
             $kirby = kirby();
-            $q = new Query($this->query, [
+            $isPageOrSite = is_a($model, Page::class) || is_a($model, Site::class);
+            $context = [
                 'kirby' => $kirby,
                 'site' => $kirby->site(),
                 'pages' => $kirby->site()->pages(),
-                'page' => $this->model()
-            ]);
+                'model' => $model,
+                'page' => $isPageOrSite ? $model : $model->parent(),
+                'user' => $isPageOrSite ? null : $model,
+                'file' => $isPageOrSite ? null : $model,
+            ];
 
-            $pages = $q->result();
+            $pages = null;
+
+            // check if Kirby\Query\Query class exists (new in 3.8)
+            if (class_exists('Kirby\\Query\\Query')) {
+                $q = new Kirby\Query\Query($query);
+                $pages = $q->resolve($context);
+            } else {
+                $q = new Kirby\Toolkit\Query($query, $context);
+                $pages = $q->result();
+            }
 
             if (!is_a($pages, \Kirby\Cms\Pages::class)) {
                 $result = $pages === null ? 'null' : get_class($pages);


### PR DESCRIPTION
The native `pages` section can only be used on page and site blueprints, not on user or file blueprints. As far as I can tell, there is no reason to prevent using `pagesdisplay` everywhere, i.e on a user view to show their latest contributions. But in this case a query value needs to be present.  https://github.com/getkirby/kirby/blob/3.8.3/config/sections/pages.php#L54